### PR TITLE
temp nolint

### DIFF
--- a/api/v3/wms_validation.go
+++ b/api/v3/wms_validation.go
@@ -36,7 +36,9 @@ func (wms *WMS) ValidateUpdate(wmsOld *WMS) ([]string, error) {
 	return ValidateUpdate(wms, wmsOld, ValidateWMS)
 }
 
-// TODO fix linting (cyclop)
+// TODO fix linting (cyclop,funlen)
+//
+//nolint:cyclop,funlen
 func ValidateWMS(wms *WMS, warnings *[]string, allErrs *field.ErrorList) {
 	if strings.Contains(wms.GetName(), "wms") {
 		sharedValidation.AddWarning(
@@ -203,6 +205,7 @@ func ValidateWMS(wms *WMS, warnings *[]string, allErrs *field.ErrorList) {
 		}
 
 		// TODO fix linting (nestif)
+		//nolint:nestif
 		if layer.Visible {
 			hasVisibleLayer = true
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,7 +78,9 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// TODO fix linting (cyclop)
+// TODO fix linting (cyclop,funlen)
+//
+//nolint:cyclop,funlen
 func main() {
 	var metricsAddr string
 	var certDir string

--- a/config/crd/update_openapi.go
+++ b/config/crd/update_openapi.go
@@ -19,6 +19,8 @@ func main() {
 }
 
 // TODO fix linting (funlen)
+//
+//nolint:funlen
 func updateWMSV3Layers(crdDir string) {
 	path := filepath.Join(crdDir, "pdok.nl_wms.yaml")
 

--- a/internal/controller/capabilitiesgenerator/mapper.go
+++ b/internal/controller/capabilitiesgenerator/mapper.go
@@ -166,6 +166,7 @@ func mapServiceProvider(provider *smoothoperatorv1.ServiceProvider) (serviceProv
 	}
 
 	// TODO fix linting (nestif)
+	//nolint:nestif
 	if provider.ServiceContact != nil {
 		serviceProvider.ServiceContact = &wfs200.ServiceContact{
 			IndividualName: provider.ServiceContact.IndividualName,
@@ -363,6 +364,8 @@ func getDcpType(url string, fillPost bool) *wms130.DCPType {
 }
 
 // TODO fix linting (funlen)
+//
+//nolint:funlen
 func getLayers(wms *pdoknlv3.WMS, canonicalURL string) []wms130.Layer {
 	result := make([]wms130.Layer, 0)
 	referenceLayer := wms.Spec.Service.Layer

--- a/internal/controller/mapfilegenerator/mapper.go
+++ b/internal/controller/mapfilegenerator/mapper.go
@@ -221,6 +221,8 @@ func MapWMSToMapfileGeneratorInput(wms *pdoknlv3.WMS, _ *smoothoperatorv1.OwnerI
 }
 
 // TODO fix linting (cyclop)
+//
+//nolint:cyclop
 func getWMSLayer(serviceLayer pdoknlv3.Layer, serviceExtent string, wms *pdoknlv3.WMS) WMSLayer {
 	layerExtent := serviceExtent
 	if len(serviceLayer.BoundingBoxes) > 0 {

--- a/internal/controller/mapserver/deployment.go
+++ b/internal/controller/mapserver/deployment.go
@@ -30,6 +30,8 @@ const (
 )
 
 // TODO fix linting (funlen)
+//
+//nolint:funlen
 func GetVolumesForDeployment[O pdoknlv3.WMSWFS](obj O, configMapNames types.HashedConfigMapNames) []v1.Volume {
 	baseVolume := v1.Volume{Name: "base"}
 	if use, size := mapperutils.UseEphemeralVolume(obj); use {
@@ -227,8 +229,10 @@ func GetEnvVarsForDeployment[O pdoknlv3.WMSWFS](obj O, blobsSecretName string) [
 	}
 }
 
-// TODO fix linting (cyclop)
+// TODO fix linting (cyclop,funlen)
 // Resources for mapserver container
+//
+//nolint:cyclop,funlen
 func GetResourcesForDeployment[O pdoknlv3.WMSWFS](obj O) v1.ResourceRequirements {
 	resources := v1.ResourceRequirements{
 		Limits:   v1.ResourceList{},

--- a/internal/controller/shared_controller.go
+++ b/internal/controller/shared_controller.go
@@ -1012,7 +1012,9 @@ func getFinalizerName[O pdoknlv3.WMSWFS](obj O) string {
 	return strings.ToLower(string(obj.Type())) + "." + pdoknlv3.GroupVersion.Group + "/finalizer"
 }
 
-// TODO fix linting (cyclop)
+// TODO fix linting (cyclop,funlen)
+//
+//nolint:cyclop,funlen
 func createOrUpdateAllForWMSWFS[R Reconciler, O pdoknlv3.WMSWFS](ctx context.Context, r R, obj O, ownerInfo *smoothoperatorv1.OwnerInfo) (operationResults map[string]controllerutil.OperationResult, err error) {
 	operationResults = make(map[string]controllerutil.OperationResult)
 	reconcilerClient := getReconcilerClient(r)
@@ -1084,6 +1086,7 @@ func createOrUpdateAllForWMSWFS[R Reconciler, O pdoknlv3.WMSWFS](ctx context.Con
 	// end region ConfigMap-BlobDownload
 
 	// TODO fix linting (nestif)
+	//nolint:nestif
 	if obj.Type() == pdoknlv3.ServiceTypeWMS {
 		wms, _ := any(obj).(*pdoknlv3.WMS)
 		wmsReconciler := (*WMSReconciler)(r)
@@ -1220,6 +1223,8 @@ func createOrUpdateAllForWMSWFS[R Reconciler, O pdoknlv3.WMSWFS](ctx context.Con
 }
 
 // TODO fix linting (funlen)
+//
+//nolint:funlen
 func deleteAllForWMSWFS[R Reconciler, O pdoknlv3.WMSWFS](ctx context.Context, r R, obj O, ownerInfo *smoothoperatorv1.OwnerInfo) (err error) {
 	bareObjects := getSharedBareObjects(obj)
 	var objects []client.Object

--- a/internal/controller/wfs_controller.go
+++ b/internal/controller/wfs_controller.go
@@ -68,6 +68,8 @@ type WFSReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.0/pkg/reconcile
 // TODO fix linting (dupl)
+//
+//nolint:dupl
 func (r *WFSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	lgr := log.FromContext(ctx)
 	lgr.Info("Starting reconcile for WFS resource", "name", req.NamespacedName)

--- a/internal/controller/wms_controller.go
+++ b/internal/controller/wms_controller.go
@@ -79,6 +79,8 @@ type WMSReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.0/pkg/reconcile
 // TODO fix linting (dupl)
+//
+//nolint:dupl
 func (r *WMSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	lgr := log.FromContext(ctx)
 	lgr.Info("Starting reconcile for WMS resource", "name", req.NamespacedName)

--- a/internal/webhook/v3/wfs_webhook.go
+++ b/internal/webhook/v3/wfs_webhook.go
@@ -22,9 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+//nolint:dupl
 package v3
 
-// TODO fix linting (dupl)
 import (
 	"context"
 	"fmt"

--- a/internal/webhook/v3/wms_webhook.go
+++ b/internal/webhook/v3/wms_webhook.go
@@ -22,9 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+//nolint:dupl
 package v3
 
-// TODO fix linting (dupl)
 import (
 	"context"
 	"fmt"


### PR DESCRIPTION
# Description

set temporary nolint comments on all known linting errors
these will slowly be fixed
but to avoid new linting errors appearing, they've been set to nolint in master

exception the webhook nolint:dupl
this one is permanent, because not really able to be deduplicated

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR