### PR TITLE
remove finalizer code

### DIFF
--- a/internal/controller/shared_controller_test.go
+++ b/internal/controller/shared_controller_test.go
@@ -39,7 +39,7 @@ func getHashedConfigMapNameFromClient[O pdoknlv3.WMSWFS](ctx context.Context, ob
 	return "", fmt.Errorf("configmap %s not found", volumeName)
 }
 
-func getExpectedObjects[O pdoknlv3.WMSWFS](ctx context.Context, obj O, includeBlobDownload bool) ([]client.Object, error) {
+func getExpectedObjects[O pdoknlv3.WMSWFS](ctx context.Context, obj O, includeBlobDownload bool, includeMapfileGeneratorConfigMap bool) ([]client.Object, error) {
 	bareObjects := getSharedBareObjects(obj)
 	var objects []client.Object
 
@@ -59,13 +59,15 @@ func getExpectedObjects[O pdoknlv3.WMSWFS](ctx context.Context, obj O, includeBl
 	cm.Name = hashedName
 	objects = append(objects, cm)
 
-	cm = getBareConfigMapMapfileGenerator(obj)
-	hashedName, err = getHashedConfigMapNameFromClient(ctx, obj, mapserver.ConfigMapMapfileGeneratorVolumeName)
-	if err != nil {
-		return objects, err
+	if includeMapfileGeneratorConfigMap {
+		cm = getBareConfigMapMapfileGenerator(obj)
+		hashedName, err = getHashedConfigMapNameFromClient(ctx, obj, mapserver.ConfigMapMapfileGeneratorVolumeName)
+		if err != nil {
+			return objects, err
+		}
+		cm.Name = hashedName
+		objects = append(objects, cm)
 	}
-	cm.Name = hashedName
-	objects = append(objects, cm)
 
 	cm = getBareConfigMapCapabilitiesGenerator(obj)
 	hashedName, err = getHashedConfigMapNameFromClient(ctx, obj, mapserver.ConfigMapCapabilitiesGeneratorVolumeName)

--- a/internal/controller/wfs_controller.go
+++ b/internal/controller/wfs_controller.go
@@ -29,7 +29,6 @@ import (
 
 	pdoknlv3 "github.com/pdok/mapserver-operator/api/v3"
 	smoothoperatorv1 "github.com/pdok/smooth-operator/api/v1"
-	smoothoperatorutils "github.com/pdok/smooth-operator/pkg/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -98,17 +97,6 @@ func (r *WFSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 			lgr.Error(err, "unable to fetch OwnerInfo resource", "error", err)
 		}
 		return result, client.IgnoreNotFound(err)
-	}
-
-	lgr.Info("Get object full name")
-	fullName := smoothoperatorutils.GetObjectFullName(r.Client, wfs)
-	lgr.Info("Finalize if necessary")
-	shouldContinue, err := smoothoperatorutils.FinalizeIfNecessary(ctx, r.Client, wfs, getFinalizerName(wfs), func() error {
-		lgr.Info("deleting resources", "name", fullName)
-		return deleteAllForWMSWFS(ctx, r, wfs, ownerInfo)
-	})
-	if !shouldContinue || err != nil {
-		return result, err
 	}
 
 	lgr.Info("creating resources for wfs", "wfs", wfs)

--- a/internal/controller/wfs_controller_test.go
+++ b/internal/controller/wfs_controller_test.go
@@ -28,7 +28,6 @@ package controller
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"slices"
 
@@ -73,6 +72,7 @@ var _ = Describe("WFS Controller", func() {
 			Name:      ownerInfoResourceName,
 		}
 		ownerInfo := &smoothoperatorv1.OwnerInfo{}
+		initScripts, includeMapfileGeneratorConfigMap := true, true
 
 		BeforeEach(func() {
 			pdoknlv3.SetHost("localhost")
@@ -121,6 +121,20 @@ var _ = Describe("WFS Controller", func() {
 
 			By("Cleanup the specific resource instance OwnerInfo")
 			Expect(k8sClient.Delete(ctx, ownerInfoResource)).To(Succeed())
+
+			// the testEnv does not do garbage collection (https://book.kubebuilder.io/reference/envtest#testing-considerations)
+			By("Cleaning Owned Resources")
+			objects, err := getExpectedObjects(ctx, wfs, initScripts, includeMapfileGeneratorConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+			for _, o := range objects {
+				objectKey := client.ObjectKey{
+					Namespace: o.GetNamespace(),
+					Name:      o.GetName(),
+				}
+				err := k8sClient.Get(ctx, objectKey, o)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(k8sClient.Delete(ctx, o)).To(Succeed())
+			}
 		})
 
 		It("Should successfully reconcile the resource", func() {
@@ -130,7 +144,8 @@ var _ = Describe("WFS Controller", func() {
 			reconcileWFS(controllerReconciler, wfs, typeNamespacedNameWfs)
 
 			By("Waiting for the owned resources to be created")
-			expectedBareObjects, err := getExpectedObjects(ctx, wfs, false)
+			initScripts = false
+			expectedBareObjects, err := getExpectedObjects(ctx, wfs, initScripts, includeMapfileGeneratorConfigMap)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() error {
@@ -149,32 +164,6 @@ var _ = Describe("WFS Controller", func() {
 			// TODO fix
 			Expect(len(wfs.Status.Conditions)).To(BeEquivalentTo(1))
 			Expect(wfs.Status.Conditions[0].Status).To(BeEquivalentTo(metav1.ConditionTrue))
-
-			By("Deleting the WFS")
-			Expect(k8sClient.Delete(ctx, wfs)).To(Succeed())
-
-			By("Reconciling the WFS again")
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedNameWfs})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Waiting for the owned resources to be deleted")
-			Eventually(func() error {
-				for _, o := range expectedBareObjects {
-					// TODO make finalizers work in the test environment
-					if len(o.GetFinalizers()) > 0 {
-						continue
-					}
-
-					err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: o.GetName()}, o)
-					if err == nil {
-						return errors.New("expected " + smoothoperatorutils.GetObjectFullName(k8sClient, o) + " to not be found")
-					}
-					if !k8serrors.IsNotFound(err) {
-						return err
-					}
-				}
-				return nil
-			}, "10s", "1s").Should(Not(HaveOccurred()))
 		})
 
 		It("Should successfully reconcile after a change in an owned resource", func() {
@@ -671,14 +660,6 @@ func reconcileWFS(r *WFSReconciler, wfs *pdoknlv3.WFS, typeNamespacedNameWfs typ
 
 	// Check it's there
 	err = k8sClient.Get(ctx, typeNamespacedNameWfs, wfs)
-	Expect(err).NotTo(HaveOccurred())
-
-	// Check finalizers
-	finalizerName := getFinalizerName(wfs)
-	Expect(wfs.Finalizers).To(ContainElement(finalizerName))
-
-	// Reconcile again
-	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedNameWfs})
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/internal/controller/wms_controller.go
+++ b/internal/controller/wms_controller.go
@@ -110,17 +110,6 @@ func (r *WMSReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 		return result, client.IgnoreNotFound(err)
 	}
 
-	lgr.Info("Get object full name")
-	fullName := smoothoperatorutils.GetObjectFullName(r.Client, wms)
-	lgr.Info("Finalize if necessary")
-	shouldContinue, err := smoothoperatorutils.FinalizeIfNecessary(ctx, r.Client, wms, getFinalizerName(wms), func() error {
-		lgr.Info("deleting resources", "name", fullName)
-		return deleteAllForWMSWFS(ctx, r, wms, ownerInfo)
-	})
-	if !shouldContinue || err != nil {
-		return result, err
-	}
-
 	lgr.Info("creating resources for wms", "wms", wms)
 	operationResults, err := createOrUpdateAllForWMSWFS(ctx, r, wms, ownerInfo)
 	if err != nil {


### PR DESCRIPTION
# Description

removed finalizer code, because we only use the finalizer to delete all child resources
something that k8s already does automatically because of OwnerReferences
therefor it's an unneeded redundancy that creates more problems than it solves
and therefor  removed

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR