### PR TITLE
Operator gebruikt v2 labels (dataset-owner) daarover crashed v3

### DIFF
--- a/internal/controller/shared_controller.go
+++ b/internal/controller/shared_controller.go
@@ -515,7 +515,10 @@ func makeUptimeName[O pdoknlv3.WMSWFS](obj O) (string, error) {
 
 	ownerID, ok := obj.GetLabels()["dataset-owner"]
 	if !ok {
-		return "", errors.New("dataset-owner label not found in object")
+		ownerID, ok = obj.GetLabels()["pdok.nl/owner-id"]
+		if !ok {
+			return "", errors.New("dataset-owner and pdok.nl/owner-id labels are not found in object")
+		}
 	}
 	parts = append(parts, strings.ToUpper(strings.ReplaceAll(ownerID, "-", "")))
 


### PR DESCRIPTION
# Description

Operator gebruikt v2 labels (dataset-owner) daarover crashed v3

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR