### PR TITLE
remove finding blobs and postgres configmap/secret

### DIFF
--- a/internal/controller/blobdownload/blob_download.go
+++ b/internal/controller/blobdownload/blob_download.go
@@ -33,7 +33,7 @@ func GetScript() string {
 	return GpkgDownloadScript
 }
 
-func GetBlobDownloadInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Images, blobsConfigName, blobsSecretName string) (*corev1.Container, error) {
+func GetBlobDownloadInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Images) (*corev1.Container, error) {
 	blobkeys := []string{}
 	for _, gpkg := range obj.GeoPackages() {
 		// Deduplicate blobkeys to prevent double downloads
@@ -55,10 +55,6 @@ func GetBlobDownloadInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Images,
 				Name:  "GEOPACKAGE_DOWNLOAD_LIST",
 				Value: strings.Join(blobkeys, ";"),
 			},
-		},
-		EnvFrom: []corev1.EnvFromSource{
-			utils.NewEnvFromSource(utils.EnvFromSourceTypeConfigMap, blobsConfigName),
-			utils.NewEnvFromSource(utils.EnvFromSourceTypeSecret, blobsSecretName),
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/internal/controller/mapfilegenerator/mapfile_generator.go
+++ b/internal/controller/mapfilegenerator/mapfile_generator.go
@@ -15,7 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func GetMapfileGeneratorInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Images, postgisConfigName, postgisSecretName string) (*corev1.Container, error) {
+func GetMapfileGeneratorInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Images) (*corev1.Container, error) {
 	initContainer := corev1.Container{
 		Name:            constants.MapfileGeneratorName,
 		Image:           images.MapfileGeneratorImage,
@@ -37,13 +37,7 @@ func GetMapfileGeneratorInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Ima
 		stylingFilesVolMount := corev1.VolumeMount{Name: constants.ConfigMapStylingFilesVolumeName, MountPath: "/styling", ReadOnly: true}
 		initContainer.VolumeMounts = append(initContainer.VolumeMounts, stylingFilesVolMount)
 	}
-	// Additional mapfile-generator configuration
-	if obj.HasPostgisData() {
-		initContainer.EnvFrom = []corev1.EnvFromSource{
-			utils.NewEnvFromSource(utils.EnvFromSourceTypeConfigMap, postgisConfigName),
-			utils.NewEnvFromSource(utils.EnvFromSourceTypeSecret, postgisSecretName),
-		}
-	}
+
 	return &initContainer, nil
 }
 

--- a/internal/controller/mapserver/deployment.go
+++ b/internal/controller/mapserver/deployment.go
@@ -17,7 +17,7 @@ import (
 
 const mimeTextXML = "text/xml"
 
-func GetMapserverContainer[O pdoknlv3.WMSWFS](obj O, images types.Images, blobsSecretName string) (*corev1.Container, error) {
+func GetMapserverContainer[O pdoknlv3.WMSWFS](obj O, images types.Images) (*corev1.Container, error) {
 	livenessProbe, readinessProbe, startupProbe, err := getProbes(obj)
 	if err != nil {
 		return nil, err
@@ -38,15 +38,6 @@ func GetMapserverContainer[O pdoknlv3.WMSWFS](obj O, images types.Images, blobsS
 				Value: "/srv/mapserver/config/default_mapserver.conf",
 			},
 			GetMapfileEnvVar(obj),
-			{
-				Name: "AZURE_STORAGE_CONNECTION_STRING",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: blobsSecretName},
-						Key:                  "AZURE_STORAGE_CONNECTION_STRING",
-					},
-				},
-			},
 		},
 		VolumeMounts: getVolumeMounts(obj.Mapfile() != nil),
 		Resources: corev1.ResourceRequirements{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -133,7 +133,7 @@ var _ = BeforeSuite(func() {
 	// Deploy blob configmap + secret
 	blobConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      blobsConfigPrefix + "testtest",
+			Name:      "blobs-testtest",
 			Namespace: metav1.NamespaceDefault,
 		},
 	}
@@ -142,7 +142,7 @@ var _ = BeforeSuite(func() {
 
 	blobSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      blobsSecretPrefix + "testtest",
+			Name:      "blobs-testtest",
 			Namespace: metav1.NamespaceDefault,
 		},
 	}
@@ -152,7 +152,7 @@ var _ = BeforeSuite(func() {
 	// Deploy postgres configmap + secret
 	postgresConfig := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      postgisConfigPrefix + "testtest",
+			Name:      "postgres-testtest",
 			Namespace: metav1.NamespaceDefault,
 		},
 	}
@@ -161,7 +161,7 @@ var _ = BeforeSuite(func() {
 
 	postgresSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      postgisSecretPrefix + "testtest",
+			Name:      "postgres-testtest",
 			Namespace: metav1.NamespaceDefault,
 		},
 	}

--- a/internal/controller/test_data/wfs/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/complete/expected/deployment.yaml
@@ -56,17 +56,17 @@ spec:
       containers:
         - name: mapserver
           env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WFS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/service.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: File

--- a/internal/controller/test_data/wfs/complete/input/wfs.yaml
+++ b/internal/controller/test_data/wfs/complete/input/wfs.yaml
@@ -28,17 +28,36 @@ spec:
     minReplicas: 1
   options: {}
   podSpecPatch:
+    initContainers:
+      - name: blob-download
+        envFrom:
+          - configMapRef:
+              name: blobs-testtest
+          - secretRef:
+              name: blobs-testtest
+      - name: mapfile-generator
+        envFrom:
+          - configMapRef:
+              name: postgres-testtest
+          - secretRef:
+              name: postgres-testtest
     containers:
-    - name: mapserver
-      resources:
-        limits:
-          cpu: "2"
-          ephemeral-storage: 11G
-          memory: 500M
-        requests:
-          cpu: "1"
-          ephemeral-storage: 11G
-          memory: 250M
+      - name: mapserver
+        env:
+          - name: AZURE_STORAGE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: AZURE_STORAGE_CONNECTION_STRING
+                name: blobs-testtest
+        resources:
+          limits:
+            cpu: "2"
+            ephemeral-storage: 11G
+            memory: 500M
+          requests:
+            cpu: "1"
+            ephemeral-storage: 11G
+            memory: 250M
   service:
     abstract: some "Service" abstract
     accessConstraints: http://creativecommons.org/publicdomain/zero/1.0/deed.nl

--- a/internal/controller/test_data/wfs/minimal/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/minimal/expected/deployment.yaml
@@ -52,17 +52,17 @@ spec:
     spec:
       containers:
         - env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WFS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/service.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           terminationMessagePath: /dev/termination-log

--- a/internal/controller/test_data/wfs/minimal/input/wfs.yaml
+++ b/internal/controller/test_data/wfs/minimal/input/wfs.yaml
@@ -11,8 +11,21 @@ metadata:
 spec:
   options: {}
   podSpecPatch:
+    initContainers:
+    - name: blob-download
+      envFrom:
+      - configMapRef:
+          name: blobs-testtest
+      - secretRef:
+          name: blobs-testtest
     containers:
     - name: mapserver
+      env:
+      - name: AZURE_STORAGE_CONNECTION_STRING
+        valueFrom:
+          secretKeyRef:
+            key: AZURE_STORAGE_CONNECTION_STRING
+            name: blobs-testtest
       resources:
         limits:
           ephemeral-storage: 100M

--- a/internal/controller/test_data/wfs/noprefetch/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/noprefetch/expected/deployment.yaml
@@ -52,17 +52,17 @@ spec:
     spec:
       containers:
         - env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WFS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/service.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           terminationMessagePath: /dev/termination-log

--- a/internal/controller/test_data/wfs/noprefetch/input/wfs.yaml
+++ b/internal/controller/test_data/wfs/noprefetch/input/wfs.yaml
@@ -12,8 +12,21 @@ spec:
   options:
     prefetchData: false
   podSpecPatch:
+    initContainers:
+    - name: blob-download
+      envFrom:
+      - configMapRef:
+          name: blobs-testtest
+      - secretRef:
+          name: blobs-testtest
     containers:
     - name: mapserver
+      env:
+      - name: AZURE_STORAGE_CONNECTION_STRING
+        valueFrom:
+          secretKeyRef:
+            key: AZURE_STORAGE_CONNECTION_STRING
+            name: blobs-testtest
       resources:
         limits:
           ephemeral-storage: 100M

--- a/internal/controller/test_data/wms/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/complete/expected/deployment.yaml
@@ -57,17 +57,17 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WMS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/service.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           lifecycle:

--- a/internal/controller/test_data/wms/complete/input/wms.yaml
+++ b/internal/controller/test_data/wms/complete/input/wms.yaml
@@ -35,17 +35,36 @@ spec:
   options:
     rewriteGroupToDataLayers: true
   podSpecPatch:
+    initContainers:
+      - name: blob-download
+        envFrom:
+          - configMapRef:
+              name: blobs-testtest
+          - secretRef:
+              name: blobs-testtest
+      - name: mapfile-generator
+        envFrom:
+          - configMapRef:
+              name: postgres-testtest
+          - secretRef:
+              name: postgres-testtest
     containers:
-    - name: mapserver
-      resources:
-        limits:
-          cpu: "4"
-          ephemeral-storage: 11G
-          memory: 100M
-        requests:
-          cpu: "2"
-          ephemeral-storage: 11G
-          memory: 50M
+      - name: mapserver
+        env:
+          - name: AZURE_STORAGE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: AZURE_STORAGE_CONNECTION_STRING
+                name: blobs-testtest
+        resources:
+          limits:
+            cpu: "4"
+            ephemeral-storage: 11G
+            memory: 100M
+          requests:
+            cpu: "2"
+            ephemeral-storage: 11G
+            memory: 50M
   service:
     prefix: dataset
     abstract: some "service" abstract

--- a/internal/controller/test_data/wms/custom-mapfile/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/custom-mapfile/expected/deployment.yaml
@@ -55,17 +55,17 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WMS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/mapfile.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           lifecycle:

--- a/internal/controller/test_data/wms/custom-mapfile/input/wms.yaml
+++ b/internal/controller/test_data/wms/custom-mapfile/input/wms.yaml
@@ -13,11 +13,24 @@ metadata:
 spec:
   options: {}
   podSpecPatch:
+    initContainers:
+      - name: blob-download
+        envFrom:
+          - configMapRef:
+              name: blobs-testtest
+          - secretRef:
+              name: blobs-testtest
     containers:
-    - name: mapserver
-      resources:
-        limits:
-          ephemeral-storage: 100m
+      - name: mapserver
+        env:
+          - name: AZURE_STORAGE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: AZURE_STORAGE_CONNECTION_STRING
+                name: blobs-testtest
+        resources:
+          limits:
+            ephemeral-storage: 100m
   service:
     prefix: dataset
     abstract: service-abstract

--- a/internal/controller/test_data/wms/minimal/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/minimal/expected/deployment.yaml
@@ -55,17 +55,17 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WMS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/service.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           lifecycle:

--- a/internal/controller/test_data/wms/minimal/input/wms.yaml
+++ b/internal/controller/test_data/wms/minimal/input/wms.yaml
@@ -13,11 +13,24 @@ metadata:
 spec:
   options: {}
   podSpecPatch:
+    initContainers:
+      - name: blob-download
+        envFrom:
+          - configMapRef:
+              name: blobs-testtest
+          - secretRef:
+              name: blobs-testtest
     containers:
-    - name: mapserver
-      resources:
-        limits:
-          ephemeral-storage: 100m
+      - name: mapserver
+        env:
+          - name: AZURE_STORAGE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: AZURE_STORAGE_CONNECTION_STRING
+                name: blobs-testtest
+        resources:
+          limits:
+            ephemeral-storage: 100m
   service:
     prefix: dataset
     abstract: service-abstract

--- a/internal/controller/test_data/wms/noprefetch/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/noprefetch/expected/deployment.yaml
@@ -55,17 +55,17 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - env:
+            - name: AZURE_STORAGE_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  key: AZURE_STORAGE_CONNECTION_STRING
+                  name: blobs-testtest
             - name: SERVICE_TYPE
               value: WMS
             - name: MAPSERVER_CONFIG_FILE
               value: "/srv/mapserver/config/default_mapserver.conf"
             - name: MS_MAPFILE
               value: /srv/data/config/mapfile/service.map
-            - name: AZURE_STORAGE_CONNECTION_STRING
-              valueFrom:
-                secretKeyRef:
-                  key: AZURE_STORAGE_CONNECTION_STRING
-                  name: blobs-testtest
           image: test.test/image:test3
           imagePullPolicy: IfNotPresent
           lifecycle:

--- a/internal/controller/test_data/wms/noprefetch/input/wms.yaml
+++ b/internal/controller/test_data/wms/noprefetch/input/wms.yaml
@@ -14,11 +14,24 @@ spec:
   options:
     prefetchData: false
   podSpecPatch:
+    initContainers:
+      - name: blob-download
+        envFrom:
+          - configMapRef:
+              name: blobs-testtest
+          - secretRef:
+              name: blobs-testtest
     containers:
-    - name: mapserver
-      resources:
-        limits:
-          ephemeral-storage: 100m
+      - name: mapserver
+        env:
+          - name: AZURE_STORAGE_CONNECTION_STRING
+            valueFrom:
+              secretKeyRef:
+                key: AZURE_STORAGE_CONNECTION_STRING
+                name: blobs-testtest
+        resources:
+          limits:
+            ephemeral-storage: 100m
   service:
     prefix: dataset
     abstract: service-abstract

--- a/internal/controller/test_data/wms/patches/input/wms.yaml
+++ b/internal/controller/test_data/wms/patches/input/wms.yaml
@@ -128,6 +128,11 @@ spec:
         image: patch.patch/image:patch
     initContainers:
       - name: blob-download
+        envFrom:
+          - configMapRef:
+              name: blobs-testtest
+          - secretRef:
+              name: blobs-testtest
         resources:
           requests:
             cpu: '3'


### PR DESCRIPTION
# Description

Removed code to find and inject configmaps and secrets
this needs to go through the podspecpatch cause

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR