### PR TITLE
Set GPKG's to read-only explicitly, instead of the base volume.

### DIFF
--- a/internal/controller/blobdownload/blob_download.go
+++ b/internal/controller/blobdownload/blob_download.go
@@ -63,7 +63,7 @@ func GetBlobDownloadInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Images)
 		},
 		Command: []string{"/bin/sh", "-c"},
 		VolumeMounts: []corev1.VolumeMount{
-			utils.GetBaseVolumeMount(false),
+			utils.GetBaseVolumeMount(),
 			utils.GetDataVolumeMount(),
 		},
 	}

--- a/internal/controller/blobdownload/gpkg_download.sh
+++ b/internal/controller/blobdownload/gpkg_download.sh
@@ -103,6 +103,8 @@ function download() {
         echo "No hash found for $file in blob storage, skipping checksum."
     fi
 
+    # After successful download set the GPKG to readonly
+    chmod -wx $file
     echo "done"
 }
 

--- a/internal/controller/featureinfogenerator/featureinfo_generator.go
+++ b/internal/controller/featureinfogenerator/featureinfo_generator.go
@@ -27,7 +27,7 @@ func GetFeatureinfoGeneratorInitContainer(images types.Images) (*corev1.Containe
 			"feature-info",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			utils.GetBaseVolumeMount(false),
+			utils.GetBaseVolumeMount(),
 			utils.GetConfigVolumeMount(constants.ConfigMapFeatureinfoGeneratorVolumeName),
 		},
 	}

--- a/internal/controller/legendgenerator/legend_generator.go
+++ b/internal/controller/legendgenerator/legend_generator.go
@@ -40,7 +40,7 @@ exit $exit_code;
 `,
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			utils.GetBaseVolumeMount(false),
+			utils.GetBaseVolumeMount(),
 			utils.GetDataVolumeMount(),
 			{Name: constants.MapserverName, MountPath: "/srv/mapserver/config/default_mapserver.conf", SubPath: "default_mapserver.conf"},
 		},

--- a/internal/controller/mapfilegenerator/mapfile_generator.go
+++ b/internal/controller/mapfilegenerator/mapfile_generator.go
@@ -28,7 +28,7 @@ func GetMapfileGeneratorInitContainer[O pdoknlv3.WMSWFS](obj O, images types.Ima
 			"/srv/data/config/mapfile",
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			utils.GetBaseVolumeMount(false),
+			utils.GetBaseVolumeMount(),
 			utils.GetConfigVolumeMount(constants.ConfigMapMapfileGeneratorVolumeName),
 		},
 	}

--- a/internal/controller/mapserver/deployment.go
+++ b/internal/controller/mapserver/deployment.go
@@ -63,7 +63,7 @@ func GetMapserverContainer[O pdoknlv3.WMSWFS](obj O, images types.Images) (*core
 
 func getVolumeMounts(customMapfile bool) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
-		utils.GetBaseVolumeMount(true),
+		utils.GetBaseVolumeMount(),
 		utils.GetDataVolumeMount(),
 	}
 

--- a/internal/controller/mapserver/test_data/expected_volumemounts.yaml
+++ b/internal/controller/mapserver/test_data/expected_volumemounts.yaml
@@ -1,7 +1,7 @@
 volumeMounts:
 - mountPath: /srv/data
   name: base
-  readOnly: true
+  readOnly: false
 - mountPath: /var/www
   name: data
 - mountPath: /srv/mapserver/config/include.conf

--- a/internal/controller/test_data/wfs/complete/expected/configmap-init-scripts.yaml
+++ b/internal/controller/test_data/wfs/complete/expected/configmap-init-scripts.yaml
@@ -179,7 +179,7 @@ metadata:
     service-type: wfs
     service-version: v1_0
     theme: theme
-  name: complete-wfs-init-scripts-fft29bbtdd
+  name: complete-wfs-init-scripts-f8k8ffgmgh
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wfs/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/complete/expected/deployment.yaml
@@ -126,7 +126,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wfs/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/complete/expected/deployment.yaml
@@ -258,7 +258,7 @@ spec:
           name: mapserver
         - configMap:
             defaultMode: 511
-            name: complete-wfs-init-scripts-fft29bbtdd
+            name: complete-wfs-init-scripts-f8k8ffgmgh
           name: init-scripts
         - configMap:
             name: complete-wfs-capabilities-generator-mfbh8cgh5c

--- a/internal/controller/test_data/wfs/minimal/expected/configmap-init-scripts.yaml
+++ b/internal/controller/test_data/wfs/minimal/expected/configmap-init-scripts.yaml
@@ -11,7 +11,7 @@ metadata:
     pdok.nl/inspire: 'false'
     service-type: wfs
     service-version: v1_0
-  name: minimal-wfs-init-scripts-fft29bbtdd
+  name: minimal-wfs-init-scripts-f8k8ffgmgh
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wfs/minimal/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/minimal/expected/deployment.yaml
@@ -122,7 +122,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wfs/minimal/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/minimal/expected/deployment.yaml
@@ -241,7 +241,7 @@ spec:
           name: mapserver
         - configMap:
             defaultMode: 511
-            name: minimal-wfs-init-scripts-fft29bbtdd
+            name: minimal-wfs-init-scripts-f8k8ffgmgh
           name: init-scripts
         - configMap:
             name: minimal-wfs-capabilities-generator-m46924mtk7

--- a/internal/controller/test_data/wfs/noprefetch/expected/deployment.yaml
+++ b/internal/controller/test_data/wfs/noprefetch/expected/deployment.yaml
@@ -122,7 +122,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wms/complete/expected/configmap-init-scripts.yaml
+++ b/internal/controller/test_data/wms/complete/expected/configmap-init-scripts.yaml
@@ -179,7 +179,7 @@ metadata:
     service-type: wms
     service-version: v1_0
     theme: "2016"
-  name: complete-wms-init-scripts-fft29bbtdd
+  name: complete-wms-init-scripts-f8k8ffgmgh
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wms/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/complete/expected/deployment.yaml
@@ -128,7 +128,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wms/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/complete/expected/deployment.yaml
@@ -375,7 +375,7 @@ spec:
           name: ogc-webservice-proxy-config
         - configMap:
             defaultMode: 511
-            name: complete-wms-init-scripts-fft29bbtdd
+            name: complete-wms-init-scripts-f8k8ffgmgh
           name: init-scripts
         - configMap:
             name: complete-wms-capabilities-generator-b9kmb96877

--- a/internal/controller/test_data/wms/custom-mapfile/expected/configmap-init-scripts.yaml
+++ b/internal/controller/test_data/wms/custom-mapfile/expected/configmap-init-scripts.yaml
@@ -178,7 +178,7 @@ metadata:
     pdok.nl/inspire: "false"
     service-type: wms
     service-version: v1_0
-  name: custom-mapfile-wms-init-scripts-fft29bbtdd
+  name: custom-mapfile-wms-init-scripts-f8k8ffgmgh
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wms/custom-mapfile/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/custom-mapfile/expected/deployment.yaml
@@ -131,7 +131,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wms/custom-mapfile/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/custom-mapfile/expected/deployment.yaml
@@ -325,7 +325,7 @@ spec:
           name: ogc-webservice-proxy-config
         - configMap:
             defaultMode: 511
-            name: custom-mapfile-wms-init-scripts-fft29bbtdd
+            name: custom-mapfile-wms-init-scripts-f8k8ffgmgh
           name: init-scripts
         - configMap:
             name: custom-mapfile-wms-capabilities-generator-865bt77thd

--- a/internal/controller/test_data/wms/minimal/expected/configmap-init-scripts.yaml
+++ b/internal/controller/test_data/wms/minimal/expected/configmap-init-scripts.yaml
@@ -178,7 +178,7 @@ metadata:
     pdok.nl/inspire: "false"
     service-type: wms
     service-version: v1_0
-  name: minimal-wms-init-scripts-fft29bbtdd
+  name: minimal-wms-init-scripts-f8k8ffgmgh
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wms/minimal/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/minimal/expected/deployment.yaml
@@ -131,7 +131,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wms/minimal/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/minimal/expected/deployment.yaml
@@ -339,7 +339,7 @@ spec:
           name: ogc-webservice-proxy-config
         - configMap:
             defaultMode: 511
-            name: minimal-wms-init-scripts-fft29bbtdd
+            name: minimal-wms-init-scripts-f8k8ffgmgh
           name: init-scripts
         - configMap:
             name: minimal-wms-capabilities-generator-865bt77thd

--- a/internal/controller/test_data/wms/noprefetch/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/noprefetch/expected/deployment.yaml
@@ -131,7 +131,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www
               name: data
               readOnly: false

--- a/internal/controller/test_data/wms/patches/expected/configmap-init-scripts.yaml
+++ b/internal/controller/test_data/wms/patches/expected/configmap-init-scripts.yaml
@@ -178,7 +178,7 @@ metadata:
     pdok.nl/inspire: "false"
     service-type: wms
     service-version: v1_0
-  name: patches-wms-init-scripts-fft29bbtdd
+  name: patches-wms-init-scripts-f8k8ffgmgh
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wms/patches/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/patches/expected/deployment.yaml
@@ -347,7 +347,7 @@ spec:
           name: ogc-webservice-proxy-config
         - configMap:
             defaultMode: 511
-            name: patches-wms-init-scripts-fft29bbtdd
+            name: patches-wms-init-scripts-f8k8ffgmgh
           name: init-scripts
         - configMap:
             name: patches-wms-capabilities-generator-f82hgmbht2

--- a/internal/controller/test_data/wms/patches/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/patches/expected/deployment.yaml
@@ -135,7 +135,7 @@ spec:
           volumeMounts:
             - mountPath: /srv/data/patch
               name: base
-              readOnly: true
+              readOnly: false
             - mountPath: /var/www/patch
               name: data
               readOnly: false
@@ -144,7 +144,7 @@ spec:
               mountPath: /patch
             - name: base
               mountPath: /srv/data
-              readOnly: true
+              readOnly: false
             - name: data
               mountPath: /var/www
             - mountPath: /srv/mapserver/config/include.conf

--- a/internal/controller/test_data/wms/patches/input/wms.yaml
+++ b/internal/controller/test_data/wms/patches/input/wms.yaml
@@ -113,7 +113,7 @@ spec:
         volumeMounts:
           - mountPath: /srv/data/patch
             name: base
-            readOnly: true
+            readOnly: false
           - mountPath: /var/www/patch
             name: data
             readOnly: false

--- a/internal/controller/utils/utils.go
+++ b/internal/controller/utils/utils.go
@@ -41,8 +41,8 @@ func NewEnvFromSource(t EnvFromSourceType, name string) corev1.EnvFromSource {
 	}
 }
 
-func GetBaseVolumeMount(readOnly bool) corev1.VolumeMount {
-	return corev1.VolumeMount{Name: constants.BaseVolumeName, MountPath: "/srv/data", ReadOnly: readOnly}
+func GetBaseVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{Name: constants.BaseVolumeName, MountPath: "/srv/data"}
 }
 
 func GetDataVolumeMount() corev1.VolumeMount {


### PR DESCRIPTION
# Description

Set GPKG's to read-only explicitly, instead of the base volume. A read-only base volume can lead to issues if - for instance - a configmap is mounted on a subpath of the base volume. This is specifically an issue with the WFS and a custom mapfile.

## Type of change

- Bugfix

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR