### PR TITLE
fix wfs, mapfile datasetmetadataid

### DIFF
--- a/internal/controller/mapfilegenerator/mapper.go
+++ b/internal/controller/mapfilegenerator/mapper.go
@@ -67,6 +67,10 @@ func MapWFSToMapfileGeneratorInput(wfs *pdoknlv3.WFS, ownerInfo *smoothoperatorv
 
 func getWFSLayers(service pdoknlv3.WFSService) (layers []WFSLayer) {
 	for _, featureType := range service.FeatureTypes {
+		metadataID := ""
+		if featureType.DatasetMetadataURL != nil && featureType.DatasetMetadataURL.CSW != nil {
+			metadataID = featureType.DatasetMetadataURL.CSW.MetadataIdentifier
+		}
 		layer := WFSLayer{
 			BaseLayer: BaseLayer{
 				Name:           featureType.Name,
@@ -74,7 +78,7 @@ func getWFSLayers(service pdoknlv3.WFSService) (layers []WFSLayer) {
 				Abstract:       featureType.Abstract,
 				Keywords:       strings.Join(featureType.Keywords, ","),
 				Extent:         getWFSExtent(featureType, service),
-				MetadataID:     featureType.DatasetMetadataURL.CSW.MetadataIdentifier,
+				MetadataID:     metadataID,
 				Columns:        getColumns(featureType.Data),
 				TableName:      featureType.Data.GetTableName(),
 				GeometryType:   featureType.Data.GetGeometryType(),


### PR DESCRIPTION
# Description

fix setting datasetmetadataid voor wfs mapfile layers which can be nil

## Type of change

(Remove irrelevant options)

- Minor change (typo, formatting, version bump)
- New feature
- Improvement of existing feature
- Bugfix
- Refactoring
- Configuration change
- Breaking change

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR