### PR TITLE
Use depth first layer order for OGC webservice proxy config

### DIFF
--- a/api/v3/wms_types.go
+++ b/api/v3/wms_types.go
@@ -438,6 +438,18 @@ func (layer *Layer) GetAllSublayers() []Layer {
 	return layers
 }
 
+// GetAllSublayersDepthFirst - get all sublayers of a layer depth first, the result does not include the layer itself
+func (layer *Layer) GetAllSublayersDepthFirst() []Layer {
+	layers := make([]Layer, 0)
+
+	for _, childLayer := range layer.Layers {
+		layers = append(layers, childLayer)
+		layers = append(layers, childLayer.GetAllSublayers()...)
+	}
+
+	return layers
+}
+
 func (wmsService *WMSService) GetParentLayer(layer Layer) *Layer {
 	if wmsService.Layer.Layers == nil {
 		return nil

--- a/api/v3/wms_types.go
+++ b/api/v3/wms_types.go
@@ -444,7 +444,7 @@ func (layer *Layer) GetAllSublayersDepthFirst() []Layer {
 
 	for _, childLayer := range layer.Layers {
 		layers = append(layers, childLayer)
-		layers = append(layers, childLayer.GetAllSublayers()...)
+		layers = append(layers, childLayer.GetAllSublayersDepthFirst()...)
 	}
 
 	return layers

--- a/internal/controller/ogcwebserviceproxy/ogc_webservice_proxy.go
+++ b/internal/controller/ogcwebserviceproxy/ogc_webservice_proxy.go
@@ -68,7 +68,7 @@ func GetConfig(wms *pdoknlv3.WMS) (config string, err error) {
 func MapWMSToOgcWebserviceProxyConfig(wms *pdoknlv3.WMS) (config Config, err error) {
 	dataLayersForGroupLayer := func(l pdoknlv3.Layer) []string {
 		var dataLayers []string
-		for _, childLayer := range l.GetAllSublayers() {
+		for _, childLayer := range l.GetAllSublayersDepthFirst() {
 			if childLayer.IsDataLayer() {
 				dataLayers = append(dataLayers, *childLayer.Name)
 			}

--- a/internal/controller/ogcwebserviceproxy/ogc_webservice_proxy_test.go
+++ b/internal/controller/ogcwebserviceproxy/ogc_webservice_proxy_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGetConfig(t *testing.T) {
-	tests := []string{"named-toplayer", "unnamed-toplayer"}
+	tests := []string{"named-toplayer", "unnamed-toplayer", "named-toplayer-varied-depth"}
 
 	for _, tt := range tests {
 		input, err := os.ReadFile("test_data/input/" + tt + ".yaml")

--- a/internal/controller/ogcwebserviceproxy/test_data/expected/named-toplayer-varied-depth.yaml
+++ b/internal/controller/ogcwebserviceproxy/test_data/expected/named-toplayer-varied-depth.yaml
@@ -1,0 +1,16 @@
+grouplayers:
+  grouplayer-1:
+    - datalayer-1
+    - datalayer-2
+  grouplayer-2:
+    - datalayer-1
+    - datalayer-2
+    - datalayer-3
+    - datalayer-4
+    - datalayer-5
+    - datalayer-6
+    - datalayer-7
+  grouplayer-3:
+    - datalayer-4
+    - datalayer-5
+    - datalayer-6

--- a/internal/controller/ogcwebserviceproxy/test_data/input/named-toplayer-varied-depth.yaml
+++ b/internal/controller/ogcwebserviceproxy/test_data/input/named-toplayer-varied-depth.yaml
@@ -1,0 +1,76 @@
+metadata:
+spec:
+  service:
+    abstract: ""
+    dataEPSG: ""
+    keywords: null
+    layer:
+      layers:
+        - layers:
+            - data:
+                gpkg:
+                  blobKey: blob-1
+                  columns: null
+                  geometryType: ""
+                  tableName: ""
+              name: datalayer-1
+              visible: false
+            - data:
+                gpkg:
+                  blobKey: blob-2
+                  columns: null
+                  geometryType: ""
+                  tableName: ""
+              name: datalayer-2
+              visible: false
+          name: grouplayer-1
+          visible: false
+        - data:
+            gpkg:
+              blobKey: blob-3
+              columns: null
+              geometryType: ""
+              tableName: ""
+          name: datalayer-3
+          visible: false
+        - layers:
+            - data:
+                gpkg:
+                  blobKey: blob-4
+                  columns: null
+                  geometryType: ""
+                  tableName: ""
+              name: datalayer-4
+              visible: false
+            - data:
+                gpkg:
+                  blobKey: blob-5
+                  columns: null
+                  geometryType: ""
+                  tableName: ""
+              name: datalayer-5
+              visible: false
+            - data:
+                gpkg:
+                  blobKey: blob-6
+                  columns: null
+                  geometryType: ""
+                  tableName: ""
+              name: datalayer-6
+              visible: false
+          name: grouplayer-3
+          visible: false
+        - data:
+            gpkg:
+              blobKey: blob-7
+              columns: null
+              geometryType: ""
+              tableName: ""
+          name: datalayer-7
+          visible: false
+      name: grouplayer-2
+      visible: false
+    ownerInfoRef: ""
+    prefix: ""
+    title: ""
+    url: "http://test.test/test"

--- a/internal/controller/test_data/wms/complete/expected/configmap-ogc-webservice-proxy.yaml
+++ b/internal/controller/test_data/wms/complete/expected/configmap-ogc-webservice-proxy.yaml
@@ -21,7 +21,7 @@ metadata:
     service-type: wms
     service-version: v1_0
     theme: '2016'
-  name: complete-wms-ogc-webservice-proxy-8d98h664bh
+  name: complete-wms-ogc-webservice-proxy-527f8545k9
   namespace: default
   ownerReferences:
     - apiVersion: pdok.nl/v3

--- a/internal/controller/test_data/wms/complete/expected/deployment.yaml
+++ b/internal/controller/test_data/wms/complete/expected/deployment.yaml
@@ -374,7 +374,7 @@ spec:
             defaultMode: 420
           name: mapserver
         - configMap:
-            name: complete-wms-ogc-webservice-proxy-8d98h664bh
+            name: complete-wms-ogc-webservice-proxy-527f8545k9
             defaultMode: 420
           name: ogc-webservice-proxy-config
         - configMap:


### PR DESCRIPTION
# Description

Use depth first layer order for OGC webservice proxy config

## Type of change

- Improvement of existing feature
- Bugfix

# Checklist:

- [x] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR